### PR TITLE
fix: LikeButtons 좌우 분리 및 필터 균등 너비 적용

### DIFF
--- a/frontend/components/FilterBar.tsx
+++ b/frontend/components/FilterBar.tsx
@@ -72,7 +72,7 @@ export default function FilterBar({ cities }: FilterBarProps) {
       >
         <div className="mx-auto max-w-screen-xl flex items-center gap-3 flex-wrap">
           {/* 4개 필터 드롭다운 */}
-          <div className="flex items-center gap-2 flex-wrap flex-1">
+          <div className="grid grid-cols-4 gap-2 flex-1">
             {FILTER_CONFIGS.map((config) => {
               const isActive = filters[config.key] !== "전체";
               return (
@@ -82,7 +82,7 @@ export default function FilterBar({ cities }: FilterBarProps) {
                   onValueChange={(v) => setFilter(config.key, v)}
                 >
                   <SelectTrigger
-                    className="w-36 text-sm"
+                    className="w-full text-sm"
                     style={{
                       backgroundColor: isActive
                         ? "rgba(0, 201, 167, 0.15)"

--- a/frontend/components/LikeButtons.tsx
+++ b/frontend/components/LikeButtons.tsx
@@ -44,8 +44,7 @@ export default function LikeButtons({
       className="flex items-center justify-between px-3 py-2 rounded-b-xl"
       style={{ borderTop: "1px solid rgba(255,255,255,0.06)" }}
     >
-      <div className="flex items-center gap-2">
-        <button
+      <button
           onClick={handleLike}
           className="flex items-center gap-1 px-2 py-1 rounded-lg text-xs transition-all"
           style={{
@@ -81,12 +80,11 @@ export default function LikeButtons({
                 : "1px solid transparent",
           }}
         >
-          👎{" "}
           <span style={{ fontFamily: "var(--font-space-mono)" }}>
             {localDislikes}
-          </span>
+          </span>{" "}
+          👎
         </button>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **#2 LikeButtons 레이아웃 재구성**: 래퍼 `div` 제거로 좋아요 버튼은 왼쪽, 싫어요 버튼은 오른쪽에 배치 (`justify-between` 효과 정상 동작)
- **#2 싫어요 버튼 순서 변경**: `👎 숫자` → `숫자 👎` 로 아이콘·숫자 순서 변경
- **#3 필터 컨테이너 grid 전환**: `flex flex-wrap` → `grid grid-cols-4`로 변경하여 4개 필터가 균등하게 공간 분할
- **#3 SelectTrigger 너비 전체화**: `w-36` → `w-full`로 변경하여 가용 공간 최대 활용

## Test plan

- [ ] 도시 카드 푸터에서 좋아요 버튼이 왼쪽, 싫어요 버튼이 오른쪽에 위치하는지 확인
- [ ] 싫어요 버튼 레이아웃이 `숫자 👎` 형태인지 확인
- [ ] 좋아요/싫어요 토글 동작(클릭·재클릭·상호 전환)이 정상 동작하는지 확인
- [ ] 홈페이지 필터 4개(예산·지역·환경·계절)가 균등하게 너비를 차지하는지 확인
- [ ] 정렬 드롭다운(`w-44`)은 변경 없이 우측 고정인지 확인
- [ ] `npm run lint && tsc --noEmit` 통과 확인

Closes #2, #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)