### PR TITLE
feat: 도시 상세 페이지 구현 및 워크트리 스크립트 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,8 @@ desktop.ini
 *.ntvs*
 *.njsproj
 *.sln
+
+# ===========================
+# Claude Code 내부
+# ===========================
+.claude/worktrees/

--- a/create-worktree.sh
+++ b/create-worktree.sh
@@ -9,13 +9,13 @@ ARGUMENT=$1
 WORKTREE_PATH="../worktree/$ARGUMENT"
 
 # [수정 포인트] 폴더가 이미 존재하는지 체크 (-d 옵션)
-# if [ -d "$WORKTREE_PATH" ]; then
-#     echo "정보: '$ARGUMENT' 워크트리가 이미 존재합니다. 해당 위치로 이동합니다."
-#     cd "$WORKTREE_PATH" || return 1
-#     echo "디렉토리 변경완료 $(pwd)"
-#     claude
-#     return 0
-# fi
+if [ -d "$WORKTREE_PATH" ]; then
+    echo "정보: '$ARGUMENT' 워크트리가 이미 존재합니다. 해당 위치로 이동합니다."
+    cd "$WORKTREE_PATH" || return 1
+    echo "디렉토리 변경완료 $(pwd)"
+    claude
+    return 0
+fi
 
 #워크트리 생성하고 성공하면 현재위치 변경
 if git worktree add "$WORKTREE_PATH"; then

--- a/frontend/app/cities/[id]/page.tsx
+++ b/frontend/app/cities/[id]/page.tsx
@@ -1,0 +1,203 @@
+import Image from "next/image";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { CITIES } from "@/lib/data";
+import LikeButtons from "@/components/LikeButtons";
+
+export function generateStaticParams() {
+  return CITIES.map((city) => ({ id: String(city.id) }));
+}
+
+const SCORE_LABELS: { key: keyof typeof CITIES[0]["scores"]; label: string }[] = [
+  { key: "cafe", label: "카공환경" },
+  { key: "internet", label: "인터넷" },
+  { key: "safety", label: "안전도" },
+  { key: "price", label: "물가" },
+  { key: "nature", label: "자연환경" },
+];
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function CityDetailPage({ params }: PageProps) {
+  const { id } = await params;
+  const city = CITIES.find((c) => c.id === Number(id));
+
+  if (!city) notFound();
+
+  return (
+    <div className="min-h-screen" style={{ backgroundColor: "#0a0f1a" }}>
+      {/* 이미지 헤더 */}
+      <div className="relative h-64 w-full overflow-hidden">
+        <Image
+          src={city.image}
+          alt={`${city.name} 도시 사진`}
+          fill
+          className="object-cover"
+          sizes="100vw"
+          priority
+        />
+        <div
+          className="absolute inset-0"
+          style={{
+            background:
+              "linear-gradient(to bottom, rgba(0,0,0,0.2) 0%, rgba(10,15,26,0.9) 100%)",
+          }}
+        />
+        <div className="absolute bottom-0 left-0 right-0 px-6 pb-6">
+          <Link
+            href="/"
+            className="inline-flex items-center text-xs mb-3 transition-colors"
+            style={{ color: "#8b9bb4" }}
+          >
+            ← 목록으로
+          </Link>
+          <h1
+            className="text-3xl font-bold"
+            style={{ fontFamily: "var(--font-bebas)", color: "#f0f4ff", letterSpacing: "0.05em" }}
+          >
+            {city.name}
+          </h1>
+          <p className="text-sm mt-1" style={{ color: "rgba(255,255,255,0.7)" }}>
+            {city.region}
+          </p>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-2xl px-4 py-6 space-y-6">
+        {/* 노마드 점수 + 순위 */}
+        <div
+          className="flex items-center justify-between rounded-xl px-5 py-4"
+          style={{ backgroundColor: "#111827", border: "1px solid rgba(0,201,167,0.2)" }}
+        >
+          <div>
+            <p className="text-xs mb-1" style={{ color: "#8b9bb4" }}>노마드 점수</p>
+            <p
+              className="text-4xl font-bold"
+              style={{ fontFamily: "var(--font-space-mono)", color: "#00c9a7" }}
+            >
+              {city.nomadScore}
+            </p>
+          </div>
+          <div className="text-right">
+            <p className="text-xs mb-1" style={{ color: "#8b9bb4" }}>랭킹</p>
+            <p
+              className="text-4xl font-bold"
+              style={{ fontFamily: "var(--font-space-mono)", color: city.rank <= 3 ? "#ff6b35" : "#f0f4ff" }}
+            >
+              #{city.rank}
+            </p>
+          </div>
+        </div>
+
+        {/* 기본 정보 */}
+        <div
+          className="rounded-xl px-5 py-4"
+          style={{ backgroundColor: "#111827", border: "1px solid rgba(255,255,255,0.07)" }}
+        >
+          <h2 className="text-sm font-bold mb-4" style={{ color: "#f0f4ff" }}>기본 정보</h2>
+          <div className="grid grid-cols-3 gap-4">
+            <div>
+              <p className="text-xs mb-1" style={{ color: "#8b9bb4" }}>월 예산</p>
+              <p className="text-sm font-bold" style={{ color: "#00c9a7", fontFamily: "var(--font-space-mono)" }}>
+                ₩{city.monthlyBudget}만
+              </p>
+            </div>
+            <div>
+              <p className="text-xs mb-1" style={{ color: "#8b9bb4" }}>날씨</p>
+              <p className="text-sm font-bold" style={{ color: "#f0f4ff" }}>
+                {city.weather.emoji} {city.weather.temp}°C
+              </p>
+            </div>
+            <div>
+              <p className="text-xs mb-1" style={{ color: "#8b9bb4" }}>인터넷</p>
+              <p className="text-sm font-bold" style={{ color: "#f0f4ff", fontFamily: "var(--font-space-mono)" }}>
+                {city.internetSpeed}M
+              </p>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-3 gap-4 mt-4">
+            <div>
+              <p className="text-xs mb-1" style={{ color: "#8b9bb4" }}>예산 분류</p>
+              <p className="text-sm" style={{ color: "#f0f4ff" }}>{city.budget}</p>
+            </div>
+            <div>
+              <p className="text-xs mb-1" style={{ color: "#8b9bb4" }}>지역</p>
+              <p className="text-sm" style={{ color: "#f0f4ff" }}>{city.regionCategory}</p>
+            </div>
+            <div>
+              <p className="text-xs mb-1" style={{ color: "#8b9bb4" }}>추천 계절</p>
+              <p className="text-sm" style={{ color: "#f0f4ff" }}>{city.bestSeason}</p>
+            </div>
+          </div>
+        </div>
+
+        {/* Scores */}
+        <div
+          className="rounded-xl px-5 py-4"
+          style={{ backgroundColor: "#111827", border: "1px solid rgba(255,255,255,0.07)" }}
+        >
+          <h2 className="text-sm font-bold mb-4" style={{ color: "#f0f4ff" }}>세부 점수</h2>
+          <div className="space-y-3">
+            {SCORE_LABELS.map(({ key, label }) => {
+              const score = city.scores[key];
+              const pct = (score / 5) * 100;
+              return (
+                <div key={key}>
+                  <div className="flex justify-between text-xs mb-1">
+                    <span style={{ color: "#8b9bb4" }}>{label}</span>
+                    <span style={{ color: "#00c9a7", fontFamily: "var(--font-space-mono)" }}>
+                      {score.toFixed(1)}
+                    </span>
+                  </div>
+                  <div
+                    className="w-full rounded-full h-1.5"
+                    style={{ backgroundColor: "rgba(255,255,255,0.08)" }}
+                  >
+                    <div
+                      className="h-1.5 rounded-full"
+                      style={{ width: `${pct}%`, backgroundColor: "#00c9a7" }}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* 태그 */}
+        <div
+          className="rounded-xl px-5 py-4"
+          style={{ backgroundColor: "#111827", border: "1px solid rgba(255,255,255,0.07)" }}
+        >
+          <h2 className="text-sm font-bold mb-3" style={{ color: "#f0f4ff" }}>태그</h2>
+          <div className="flex flex-wrap gap-2">
+            {city.tags.map((tag) => (
+              <span
+                key={tag}
+                className="px-3 py-1 rounded-full text-xs"
+                style={{
+                  backgroundColor: "rgba(0,201,167,0.1)",
+                  color: "#00c9a7",
+                  border: "1px solid rgba(0,201,167,0.25)",
+                }}
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        {/* 좋아요/싫어요 */}
+        <div
+          className="rounded-xl overflow-hidden"
+          style={{ backgroundColor: "#111827", border: "1px solid rgba(255,255,255,0.07)" }}
+        >
+          <LikeButtons likes={city.likes} dislikes={city.dislikes} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/CityCard.tsx
+++ b/frontend/components/CityCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
 import { City } from "@/types/city";
 import LikeButtons from "./LikeButtons";
 
@@ -41,6 +42,7 @@ export default function CityCard({ city, animationDelay }: CityCardProps) {
             "rgba(255,255,255,0.07)";
         }}
       >
+        <Link href={`/cities/${city.id}`} className="block">
         {/* 이미지 영역 */}
         <div className="relative h-40 overflow-hidden">
           <Image
@@ -141,6 +143,7 @@ export default function CityCard({ city, animationDelay }: CityCardProps) {
             ))}
           </div>
         </div>
+        </Link>
 
         {/* 카드 푸터 */}
         <LikeButtons


### PR DESCRIPTION
## Summary

- `frontend/app/cities/[id]/page.tsx` 생성: 도시 상세 페이지 구현
  - 도시 정보(이름, 위치, 요약, 예산, 환경, 계절 등) 표시
  - 좋아요/싫어요 카운트 표시
  - 목록으로 돌아가는 Back 버튼
- `frontend/components/CityCard.tsx`: 카드 클릭 시 `/cities/:id`로 이동하는 Link 연결
- `create-worktree.sh`: 기존 워크트리 재사용 로직 활성화
- `.gitignore`: `.claude/worktrees/` 항목 추가

## Test plan

- [ ] 메인 페이지 도시 카드 클릭 → `/cities/:id` 상세 페이지로 이동 확인
- [ ] 상세 페이지에서 도시 정보 정상 표시 확인
- [ ] 상세 페이지 Back 버튼 동작 확인
- [ ] 존재하지 않는 도시 ID 접근 시 처리 확인
- [ ] `create-worktree.sh` 실행 시 기존 워크트리 재사용 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)